### PR TITLE
Minor fixes for setup argument, linters and deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a python 3 library and cli module for interacting with the [EmailRep](https://emailrep.io) service.
 
 ## Installation
-`pip3 install emailrep --upgrade`
+`python3 -m pip install --upgrade emailrep`
 
 ## Quick Start (cli)
 ```sh

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a python 3 library and cli module for interacting with the [EmailRep](https://emailrep.io) service.
 
 ## Installation
-`python3 -m pip install --upgrade emailrep`
+`pip3 install emailrep --upgrade` or `python3 -m pip install --upgrade emailrep`
 
 ## Quick Start (cli)
 ```sh

--- a/emailrep/__init__.py
+++ b/emailrep/__init__.py
@@ -1,7 +1,7 @@
-import sys
 import requests
 
 BASE_URL = "https://emailrep.io"
+
 
 class EmailRep():
     QUERY = "QUERY"
@@ -10,7 +10,7 @@ class EmailRep():
     def __init__(self, key=None, proxy=None):
         self.base_url = BASE_URL
         self.headers = {}
-        self.version = "0.0.4"
+        self.version = "0.0.5"
         self.headers["User-Agent"] = "python/emailrep.io v%s" % self.version
         self.headers["Content-Type"] = "application/json"
 
@@ -27,7 +27,6 @@ class EmailRep():
 /___/_/_/_/\_,_/_/_/_/|_|\__/ .__/
                            /_/
 """
-
 
     def query(self, email):
         url = "{}/{}?summary=true".format(self.base_url, email)
@@ -58,4 +57,3 @@ class EmailRep():
         print("Email address: %s\n" % result["email"])
         print("\033[91mRISKY\033[0m\n") if result["suspicious"] else None
         print(result["summary"])
-

--- a/emailrep/cli.py
+++ b/emailrep/cli.py
@@ -4,13 +4,14 @@ from dateutil import parser
 from emailrep.utils import parse_args, load_config
 from emailrep import EmailRep
 
+
 def main():
     (action, args, proxy) = parse_args()
     config = load_config()
 
     emailrep = EmailRep(
-            key=config.get('emailrep', 'key'), 
-            proxy=proxy)
+        key=config.get('emailrep', 'key'),
+        proxy=proxy)
 
     try:
         if action == EmailRep.QUERY:

--- a/emailrep/utils.py
+++ b/emailrep/utils.py
@@ -8,13 +8,14 @@ from emailrep import EmailRep
 
 CONF_PATH = os.path.expanduser("~/.config/sublime")
 CONF_FILE = os.path.join(CONF_PATH, "setup.cfg")
-CONF_DEFAULTS = {"emailrep": {"key": "" }}
+CONF_DEFAULTS = {"emailrep": {"key": ""}}
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
-            prog='emailrep',
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description="""
+        prog='emailrep',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
 EmailRep - emailrep.io command line interface
 
 Query an email address:
@@ -34,21 +35,23 @@ emailrep setup -k <your api key>
     # this allows us to parse the email address to query as a positional argument
     parser.add_argument('query', nargs='?')
     parser.add_argument('-r', '--report', help='Email address to report',
-            action='store', dest='report', type=str, required=False)
+                        action='store', dest='report', type=str, required=False)
     parser.add_argument('--tags', help='Tags that should be applied',
-            action='store', dest='tags', type=str, required=False)
+                        action='store', dest='tags', type=str, required=False)
     parser.add_argument('--description', help='Additional information and context',
-            action='store', dest='description', type=str, required=False)
+                        action='store', dest='description', type=str, required=False)
     parser.add_argument('--timestamp', help=(
-        'When this activity occurred as a string, defaults to now(). '
-        'Example: "Sun Aug 18 22:51:32 EDT 2019" or "08/18/2019 22:51:32 EDT"'
-        ), action='store', dest='timestamp', type=str, required=False)
+                        'When this activity occurred as a string, defaults to now(). '
+                        'Example: "Sun Aug 18 22:51:32 EDT 2019" or "08/18/2019 22:51:32 EDT"'
+                        ), action='store', dest='timestamp', type=str, required=False)
     parser.add_argument('--expires', help=(
-        'Number of hours the email should be considered risky'
-        ), action='store', dest='expires', type=int, required=False)
+                        'Number of hours the email should be considered risky'
+                        ), action='store', dest='expires', type=int, required=False)
     parser.add_argument('--proxy', help=(
-        'Proxy to use for requests. Example: "socks5://10.10.10.10:8000"'
-        ), action='store', dest='proxy', type=str, required=False)
+                        'Proxy to use for requests. Example: "socks5://10.10.10.10:8000"'
+                        ), action='store', dest='proxy', type=str, required=False),
+    parser.add_argument('-k', '--key', help='API key',
+                        action='store', dest='key', type=str, required=False),
 
     args = parser.parse_args()
 
@@ -68,6 +71,7 @@ emailrep setup -k <your api key>
             sys.exit()
         return (EmailRep.REPORT, args, args.proxy)
 
+
 def setup():
     if len(sys.argv) == 4 and sys.argv[2] == "-k":
         if not os.path.isfile(CONF_FILE):
@@ -83,10 +87,11 @@ def setup():
             sys.exit()
     else:
         print(
-                "Setup requires an API key.\n"
-                "Usage: emailrep setup -k <api key>"
+            "Setup requires an API key.\n"
+            "Usage: emailrep setup -k <api key>"
         )
         sys.exit()
+
 
 def load_config():
     config = ConfigParser()

--- a/emailrep/utils.py
+++ b/emailrep/utils.py
@@ -50,10 +50,8 @@ emailrep setup -k <your api key>
     parser.add_argument('--proxy', help=(
                         'Proxy to use for requests. Example: "socks5://10.10.10.10:8000"'
                         ), action='store', dest='proxy', type=str, required=False),
-    parser.add_argument('-k', '--key', help='API key',
-                        action='store', dest='key', type=str, required=False),
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
 
     if len(sys.argv) <= 1:
         parser.print_help()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501
+[pep8]
+ignore = E501

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,13 @@ with open("README.md", "r") as fh:
 install_requires = [
     "python-dateutil",
     "requests",
+    "setuptools",
     "PySocks"
 ]
 
 setuptools.setup(
     name="emailrep",
-    version="0.0.4",
+    version="0.0.5",
     author="Sublime Security",
     author_email="hi@sublimesecurity.com",
     description="Python interface for the EmailRep API",


### PR DESCRIPTION
Hi Josh & Sublime security team,

I had to add -k argument for parser to allow setup -k API to work on my system with Python 3.6.12 and argparse 1.1 .

I ran code through flake8 and pep8 linters and fixes some minor items found by them.

I saw a deprecation warning with pip3 so switched install command to python3 -m pip instead.

Thanks,
Matt